### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that provides web search capabilities using Perplexity's API with automatic model selection based on query intent.
 
+<a href="https://glama.ai/mcp/servers/6qmvjay9z5">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/6qmvjay9z5/badge" alt="Perplexity Server MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js (v14 or higher)


### PR DESCRIPTION
This PR adds a badge for the [Perplexity MCP Server](https://glama.ai/mcp/servers/6qmvjay9z5) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/6qmvjay9z5">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/6qmvjay9z5/badge" alt="Perplexity Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.